### PR TITLE
Add BATS test debug echoes

### DIFF
--- a/tests/test_environment_variables.bats
+++ b/tests/test_environment_variables.bats
@@ -17,7 +17,7 @@ teardown_file() {
 @test "Checking APP_NAME container environment variable..." {
   # Container-wide variable; we don't need to wait for gnucash to start.
   run docker exec "${CONTAINER_DAEMON_NAME}" printenv APP_NAME
-  echo "exit status: $status"
+  echo "exit status: $status (printenv APP_NAME)"
   [ "$status" -eq 0 ]  # Environment variable could not be retrieved
   echo "lines[0]: ${lines[0]}"
   [ "${lines[0]}" = "GnuCash" ]
@@ -26,7 +26,7 @@ teardown_file() {
 @test "Checking SECURE_CONNECTION container environment variable..." {
   # Container-wide variable; we don't need to wait for gnucash to start.
   run docker exec "${CONTAINER_DAEMON_NAME}" printenv SECURE_CONNECTION
-  echo "exit status: $status"
+  echo "exit status: $status (printenv SECURE_CONNECTION)"
   [ "$status" -eq 0 ]  # Environment variable could not be retrieved
   echo "lines[0]: ${lines[0]}"
   [ "${lines[0]}" = "1" ]
@@ -52,7 +52,7 @@ get_gnucash_env() {
 
 @test "Checking XDG_CONFIG_HOME gnucash environment variable points to /config..." {
   get_gnucash_env 'XDG_CONFIG_HOME'
-  echo "exit status: $status"
+  echo "exit status: $status (get_gnucash_env 'XDG_CONFIG_HOME')"
   [ "$status" -eq 0 ]  # Environment variable could not be retrieved
   echo "lines[0]: ${lines[0]}"
   [[ "${lines[0]}" == "/config/"* ]]
@@ -60,7 +60,7 @@ get_gnucash_env() {
 
 @test "Checking XDG_DATA_HOME gnucash environment variable points to /config..." {
   get_gnucash_env 'XDG_DATA_HOME'
-  echo "exit status: $status"
+  echo "exit status: $status (get_gnucash_env 'XDG_DATA_HOME')"
   [ "$status" -eq 0 ]  # Environment variable could not be retrieved
   echo "lines[0]: ${lines[0]}"
   [[ "${lines[0]}" == "/config/"* ]]
@@ -68,7 +68,7 @@ get_gnucash_env() {
 
 @test "Checking XDG_CACHE_HOME gnucash environment variable points to /config..." {
   get_gnucash_env  'XDG_CACHE_HOME'
-  echo "exit status: $status"
+  echo "exit status: $status (get_gnucash_env 'XDG_CACHE_HOME')"
   [ "$status" -eq 0 ]  # Environment variable could not be retrieved
   echo "lines[0]: ${lines[0]}"
   [[ "${lines[0]}" == "/config/"* ]]
@@ -76,7 +76,7 @@ get_gnucash_env() {
 
 @test "Checking HOME gnucash environment variable points to /data..." {
   get_gnucash_env 'HOME'
-  echo "exit status: $status"
+  echo "exit status: $status (get_gnucash_env 'HOME')"
   [ "$status" -eq 0 ]  # Environment variable could not be retrieved
   echo "lines[0]: ${lines[0]}"
   [ "${lines[0]}" = "/data" ]

--- a/tests/test_finance_quote.bats
+++ b/tests/test_finance_quote.bats
@@ -12,13 +12,13 @@ teardown_file() {
 
 @test "Checking that Finance::Quote Perl module is installed..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" perl -mFinance::Quote -e 1
-  echo "exit status: $status"
+  echo "exit status: $status (perl -mFinance::Quote -e 1)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that Gnucash integration with Finance::Quote works..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" gnucash-cli --quotes info
-  echo "exit status: $status"
+  echo "exit status: $status (gnucash-cli --quotes info)"
   [ "$status" -eq 0 ]
   echo "output: ${output}"
   [[ "${output}" =~ "Finance::Quote version "[0-9]+\.[0-9]+ ]]

--- a/tests/test_gnucash.bats
+++ b/tests/test_gnucash.bats
@@ -12,10 +12,10 @@ teardown_file() {
 
 @test "Checking that Gnucash is installed properly..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" which gnucash
-  echo "exit status: $status"
+  echo "exit status: $status (which gnucash)"
   [ "$status" -eq 0 ]
   run docker exec "${CONTAINER_DAEMON_NAME}" test -x "${lines[0]}"
-  echo "exit status: $status"
+  echo "exit status: $status (test -x \"${lines[0]}\")"
   [ "$status" -eq 0 ]
 }
 
@@ -28,9 +28,9 @@ teardown_file() {
   wait_for_container_daemon
   run docker exec "${CONTAINER_DAEMON_NAME}" \
     sh -c 'gnucash --display=:0 --version'
-  echo gnucash --version output: "${output}"
-  echo "exit status: $status"
+  echo "exit status: $status (gnucash --display=:0 --version)"
   [ "$status" -eq 0 ]
+  echo "output: ${output}"
   [[ "${output}" =~ "GnuCash "[0-9]+\.[0-9]+ ]]
 }
 
@@ -38,7 +38,7 @@ teardown_file() {
   wait_for_container_daemon
   run docker exec "${CONTAINER_DAEMON_NAME}" \
     sh -c 'gnucash --display=:0 --paths'
-  echo "exit status: $status"
+  echo "exit status: $status (gnucash --display=:0 --paths)"
   [ "$status" -eq 0 ]
   echo "output: ${output}"
   [[ "${output}" == *"GNC_USERDATA_DIR: /config/"* ]]
@@ -48,7 +48,7 @@ teardown_file() {
   wait_for_container_daemon
   run docker exec "${CONTAINER_DAEMON_NAME}" \
     sh -c 'gnucash --display=:0 --paths'
-  echo "exit status: $status"
+  echo "exit status: $status (gnucash --display=:0 --paths)"
   [ "$status" -eq 0 ]
   echo "output: ${output}"
   [[ "${output}" == *"GNC_USERCONFIG_DIR: /config/"* ]]
@@ -57,6 +57,6 @@ teardown_file() {
 @test "Checking that Gnucash runs automatically after container start..." {
   wait_for_container_daemon
   run docker exec "${CONTAINER_DAEMON_NAME}" pgrep gnucash
-  echo "exit status: $status"
+  echo "exit status: $status (pgrep gnucash)"
   [ "$status" -eq 0 ]
 }

--- a/tests/test_gnucash_docs.bats
+++ b/tests/test_gnucash_docs.bats
@@ -12,43 +12,43 @@ teardown_file() {
 
 @test "Checking that GnuCash documentation is installed..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -d /usr/share/doc/gnucash-docs
-  echo "exit status: $status"
+  echo "exit status: $status (test -d /usr/share/doc/gnucash-docs)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that GnuCash guide directory exists..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -d /usr/share/help/C/gnucash-guide
-  echo "exit status: $status"
+  echo "exit status: $status (test -d /usr/share/help/C/gnucash-guide)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that GnuCash guide index exists..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -f /usr/share/help/C/gnucash-guide/index.docbook
-  echo "exit status: $status"
+  echo "exit status: $status (test -f /usr/share/help/C/gnucash-guide/index.docbook)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that GnuCash guide contains XML files..." {
   # *.xml needs to be quoted to prevent host shell from expanding it.
   run docker exec "${CONTAINER_DAEMON_NAME}" sh -c 'ls /usr/share/help/C/gnucash-guide/*.xml'
-  echo "exit status: $status"
+  echo "exit status: $status (ls /usr/share/help/C/gnucash-guide/*.xml)"
   [ "$status" -eq 0 ]
 }
 @test "Checking that GnuCash manual directory exists..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -d /usr/share/help/C/gnucash-manual
-  echo "exit status: $status"
+  echo "exit status: $status (test -d /usr/share/help/C/gnucash-manual)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that GnuCash manual index exists..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -f /usr/share/help/C/gnucash-manual/index.docbook
-  echo "exit status: $status"
+  echo "exit status: $status (test -f /usr/share/help/C/gnucash-manual/index.docbook)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that GnuCash manual contains XML files..." {
   # *.xml needs to be quoted to prevent host shell from expanding it.
   run docker exec "${CONTAINER_DAEMON_NAME}" sh -c 'ls /usr/share/help/C/gnucash-manual/*.xml'
-  echo "exit status: $status"
+  echo "exit status: $status (ls /usr/share/help/C/gnucash-manual/*.xml)"
   [ "$status" -eq 0 ]
 }

--- a/tests/test_icons.bats
+++ b/tests/test_icons.bats
@@ -13,9 +13,9 @@ teardown_file() {
 @test "Checking that app web icons exist..." {
   icon_dir='/opt/noVNC/app/images/icons'
   run docker exec "${CONTAINER_DAEMON_NAME}" test -d "${icon_dir}"
-  echo "exit status: $status"
+  echo "exit status: $status (test -d \"${icon_dir}\")"
   [ "$status" -eq  0 ]  # icons exists
   run docker exec "${CONTAINER_DAEMON_NAME}" test -e "${icon_dir}/favicon.ico"
-  echo "exit status: $status"
+  echo "exit status: $status (test -e \"${icon_dir}/favicon.ico\")"
   [ "$status" -eq  0 ]  # web favicon exists
 }

--- a/tests/test_mapped_volumes.bats
+++ b/tests/test_mapped_volumes.bats
@@ -15,31 +15,31 @@ teardown_file() {
   # wait for this to happen before checking.
   wait_for_container_daemon
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -e /config
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -e /config)"
   [ "$status" -eq  0 ]  # /config exists
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -d /config
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -d /config)"
   [ "$status" -eq  0 ]  # /config is a directory
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -O /config
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -O /config)"
   [ "$status" -eq  0 ]  # app user owns /config
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -G /config
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -G /config)"
   [ "$status" -eq  0 ]  # app group owns /config
 }
 
 @test "Checking that /data directory exists and is owned by app user/group..." {
   wait_for_container_daemon
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -e /data
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -e /data)"
   [ "$status" -eq  0 ]  # /data exists
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -d /data
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -d /data)"
   [ "$status" -eq  0 ]  # /data is a directory
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -O /data
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -O /data)"
   [ "$status" -eq  0 ]  # app user owns /data
   run docker exec "${CONTAINER_DAEMON_NAME}" runuser -u app -- test -G /data
-  echo "exit status: $status"
+  echo "exit status: $status (runuser -u app -- test -G /data)"
   [ "$status" -eq  0 ]  # app group owns /data
 }

--- a/tests/test_startapp_permissions.bats
+++ b/tests/test_startapp_permissions.bats
@@ -12,12 +12,12 @@ teardown_file() {
 
 @test "Checking that /startapp.sh exists..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -f /startapp.sh
-  echo "exit status: $status"
+  echo "exit status: $status (test -f /startapp.sh)"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that /startapp.sh has execute permissions..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" test -x /startapp.sh
-  echo "exit status: $status"
+  echo "exit status: $status (test -x /startapp.sh)"
   [ "$status" -eq 0 ]
 }

--- a/tests/test_yelp.bats
+++ b/tests/test_yelp.bats
@@ -12,17 +12,17 @@ teardown_file() {
 
 @test "Checking that yelp is installed properly..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" which yelp
-  echo "exit status: $status"
+  echo "exit status: $status (which yelp)"
   [ "$status" -eq 0 ]
   yelp_app="${lines[0]}"
   run docker exec "${CONTAINER_DAEMON_NAME}" test -x "${yelp_app}"
-  echo "exit status: $status"
+  echo "exit status: $status (test -x \"${yelp_app}\")"
   [ "$status" -eq 0 ]
 }
 
 @test "Checking that yelp runs..." {
   run docker exec "${CONTAINER_DAEMON_NAME}" yelp -h
-  echo "exit status: $status"
+  echo "exit status: $status (yelp -h)"
   [ "$status" -eq 0 ]
   echo "lines[0]: ${lines[0]}"
   [[ "${lines[0]}" == "Usage:"* ]]


### PR DESCRIPTION
Adds echo statements for `$status`, `$output`, and `$lines` immediately before they are checked in BATS tests.
* Status echoes include the command executed for context, e.g.,
  `echo "exit status: $status (command)"`.
* Output/Lines echoes print the variable content.

This improves debugging by providing context on test failures in CI logs.
