### PR TITLE
Use docker layer caching for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,7 @@ on:
 env:
   BASEIMAGE_VERSION: ubuntu-24.04-v4
   GNUCASH_VERSION: 5.13
-  #PLATFORMS: linux/amd64,linux/arm64
-  PLATFORMS: linux/amd64
+  PLATFORMS: linux/amd64,linux/arm64
   DOCKER_IMAGE_NAME: ${{ vars.DOCKERHUB_USERNAME }}/gnucash
 
 jobs:
@@ -25,6 +24,7 @@ jobs:
       packages: write  # Allows pushing/writing to GHCR
     services:
       registry:
+        # Ephemeral docker registry for storing images between build and test.
         image: registry:2
         ports:
           - 5000:5000
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup BATS
+      - name: Set up BATS
         uses: mig4/setup-bats@v1
         with:
           bats-version: 1.13.0
@@ -47,9 +47,10 @@ jobs:
         with:
           driver-opts: network=host
 
-      - name: Login to GitHub Container Registry
+      - name: Login to GitHub Container Registry (GHCR)
         uses: docker/login-action@v3
         with:
+          # Persistent docker registry for caching image layers across CI runs.
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
@@ -58,8 +59,7 @@ jobs:
         id: cache
         run: |
           # The cache image name must be lowercase.
-          CACHE_IMAGE_NAME="ghcr.io/${{ github.repository }}/build"
-          #CACHE_IMAGE_NAME="ghcr.io/${{ github.repository_owner }}/gnucash-build"
+          CACHE_IMAGE_NAME="ghcr.io/${{ github.repository }}/build-cache"
           CACHE_IMAGE_NAME="${CACHE_IMAGE_NAME,,}"
 
           sanitize() {
@@ -71,25 +71,25 @@ jobs:
             # but only write to the PR's cache.
             REF_NAME="${{ github.head_ref }}"
             CLEAN_REF=$(sanitize "$REF_NAME")
-            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:cache-main,ref=${CACHE_IMAGE_NAME}:cache-${CLEAN_REF}"
-            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:cache-${CLEAN_REF},mode=max"
+            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:main,ref=${CACHE_IMAGE_NAME}:${CLEAN_REF}"
+            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:${CLEAN_REF},mode=max"
 
           elif [[ $GITHUB_REF == 'refs/heads/main' ]]; then
             # For pushes to the main branch, we read from and write to the main branch cache.
-            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:cache-main"
-            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:cache-main,mode=max"
+            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:main"
+            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:main,mode=max"
 
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             # For other branches, read from main and branch cache, write to branch cache.
             REF_NAME=${GITHUB_REF#refs/heads/}
             CLEAN_REF=$(sanitize "$REF_NAME")
-            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:cache-main,ref=${CACHE_IMAGE_NAME}:cache-${CLEAN_REF}"
-            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:cache-${CLEAN_REF},mode=max"
+            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:main,ref=${CACHE_IMAGE_NAME}:${CLEAN_REF}"
+            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:${CLEAN_REF},mode=max"
 
           else
             # For all other cases (e.g., tag builds), we read from and write to the main branch cache.
-            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:cache-main"
-            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:cache-main,mode=max"
+            CACHE_FROM="type=registry,ref=${CACHE_IMAGE_NAME}:main"
+            CACHE_TO="type=registry,ref=${CACHE_IMAGE_NAME}:main,mode=max"
           fi
 
           echo "cache-from=${CACHE_FROM}" >> $GITHUB_OUTPUT
@@ -107,7 +107,7 @@ jobs:
           cache-from: ${{ steps.cache.outputs.cache-from }}
           cache-to: ${{ steps.cache.outputs.cache-to }}
 
-      - name: Inspect
+      - name: Inspect image manifest
         id: inspect
         run: |
           # Get the metadata of all platform images from the multi-platform manifest of the above build.
@@ -141,17 +141,17 @@ jobs:
             echo "Running tests on image ${DOCKER_IMAGE}..."
             docker pull ${DOCKER_IMAGE}
             docker run --rm ${DOCKER_IMAGE} sh -c 'echo Testing image on $(uname -m)...'
-            bats -j $(nproc) tests
+            bats -j $(nproc) --trace tests
           done
 
-      - name: Login to Docker Hub
+      - name: Login to Dockerhub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Prepare Github Metadata
+      - name: Prepare image metadata
         id: meta
         if: github.event_name != 'pull_request'
         run: |
@@ -202,10 +202,10 @@ jobs:
           build-args: |
             BASEIMAGE_VERSION=${{ env.BASEIMAGE_VERSION }}
             GNUCASH_VERSION=${{ env.GNUCASH_VERSION }}
-          cache-from: ${{ steps.cache.outputs.cache-from }}
-          cache-to: ${{ steps.cache.outputs.cache-to }}
+          # The local docker daemon is caching the image layers from above
+          # build, so this build should be all cached and thus very fast.
 
-      - name: Update Docker Hub description
+      - name: Update Dockerhub description
         if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         uses: peter-evans/dockerhub-description@v4
         with:


### PR DESCRIPTION
Enable Docker layer caching in the CI pipeline to speed up builds.

This change introduces the use of `ghcr.io` as a remote cache for Docker image layers. The GitHub Actions workflow has been updated to include:
- A login step for the GitHub Container Registry.
- Adds a new step to prepare cache tags with comments for clarity.
- Implement robust sanitization for branch names used as Docker cache tags, replacing invalid characters with `_`.
- `cache-from` and `cache-to` parameters in the `docker/build-push-action` to pull from and push to the cache.
- A caching strategy that uses a unique cache for each branch and the `main` branch cache for tag builds.