### PR TITLE
Refactor appready script to external file

### DIFF
--- a/tests/scripts/appready.sh
+++ b/tests/scripts/appready.sh
@@ -1,5 +1,12 @@
 #!/usr/bin/bash
 
+# This script runs as a service after the 'app' service is started. It creates a
+# notifier file 'appready' once it has verified that the final 'app' process
+# (gnucash) has actually started. In addition, it creates a shell script
+# 'appenv.sh' which can be sourced to set the exact same environment variables
+# that the 'app' sees. They are grabbed from the '/proc/<app_pid>/environ'
+# exported by the running 'app'.
+
 CONTAINER_COM_DIR='@CONTAINER_COM_DIR@'
 log="${CONTAINER_COM_DIR}/log"
 

--- a/tests/utils_container.bash
+++ b/tests/utils_container.bash
@@ -7,7 +7,8 @@ setup_container_daemon() {
     && docker rm "${CONTAINER_DAEMON_NAME}" > /dev/null 2>&1 || true
 
   # Create a service for testing that runs after the 'app' service in order to
-  # notify us that the 'app' has been started.
+  # notify us that the 'app' has been started. In addition, it exports the
+  # environment variables as the app sees them.
   # shellcheck disable=SC2154
   APPREADY_SERVICE="${TESTS_WORKDIR}/service.d/appready"
   mkdir -p "${APPREADY_SERVICE}"


### PR DESCRIPTION
Refactored the embedded `appready` script in `tests/utils_container.bash` to a standalone file `tests/scripts/appready.sh`. This improves readability and allows for linting (shellcheck). The script logic remains the same but with improved syntax and shellcheck fixes. Updated `tests/utils_container.bash` to copy the script instead of generating it via HEREDOC.

---
*PR created automatically by Jules for task [7280583032261935868](https://jules.google.com/task/7280583032261935868) started by @ArturKlauser*