### PR TITLE
Standardize BATS debug output in test_gnucash_docs.bats

### DIFF
--- a/tests/test_gnucash_docs.bats
+++ b/tests/test_gnucash_docs.bats
@@ -26,10 +26,10 @@ load utils
   run exec_in_container sh -c \
     'ls -1 /usr/share/help/C/gnucash-guide/ | grep -Ec "\.(xml|docbook)$"'
   echo "exit status: ${status}" \
-    '(ls -1 /usr/share/help/C/gnucash-guide/ | grep -Ec "\.(xml|docbook)$"'
+    '(ls -1 /usr/share/help/C/gnucash-guide/ | grep -Ec "\.(xml|docbook)$")'
   [[ "${status}" -eq 0 ]]
   # Currently there are 26 files - expect some variation with versions.
-  echo "output: ${output}"
+  echo "lines[0]: ${lines[0]}"
   [[ "${lines[0]}" -ge '20' ]]
 }
 
@@ -51,9 +51,9 @@ load utils
   run exec_in_container sh -c \
     'ls -1 /usr/share/help/C/gnucash-manual/ | grep -Ec "\.(xml|docbook)$"'
   echo "exit status: ${status}" \
-    '(ls -1 /usr/share/help/C/gnucash-manual/ | grep -Ec "\.(xml|docbook)$"'
+    '(ls -1 /usr/share/help/C/gnucash-manual/ | grep -Ec "\.(xml|docbook)$")'
   [[ "${status}" -eq 0 ]]
   # Currently there are 18 files - expect some variation with versions.
-  echo "output: ${output}"
+  echo "lines[0]: ${lines[0]}"
   [[ "${lines[0]}" -ge '12' ]]
 }


### PR DESCRIPTION
Audited `.bats` files and updated `tests/test_gnucash_docs.bats` to follow the standard debugging output convention. This includes echoing the exact variable being tested (e.g., `lines[0]` instead of `output` when asserting against `lines[0]`), fixing malformed echo statements (missing closing parentheses), and ensuring all lines are within the 80-character limit.

---
*PR created automatically by Jules for task [9350133813429172946](https://jules.google.com/task/9350133813429172946) started by @ArturKlauser*