### PR TITLE
Fix typos in documentation and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The graphical user interface (GUI) of the application can be accessed through a
 modern web browser, requiring no installation or configuration on the client
 side. Only secure access via HTTPS is supported.
 
-The docker image is based on
+The Docker image is based on
 [jlesage/docker-baseimage-gui](https://github.com/jlesage/docker-baseimage-gui).
 
 > [!NOTE]

--- a/tests/test_finance_quote.bats
+++ b/tests/test_finance_quote.bats
@@ -18,4 +18,4 @@ load utils
 
 # We intentionally don't test the actual quote retrieval. During time of test we
 # don't want to depend on remote servers which over the past have shown various
-# degrees of instability, authorization, and quota issue.
+# degrees of instability, authorization, and quota issues.

--- a/tests/test_gnucash.bats
+++ b/tests/test_gnucash.bats
@@ -24,8 +24,8 @@ load utils
 }
 
 @test "Checking that Gnucash runs..." {
-  # Modern Gnucash can't even print verion or help messages to the TTY if it
-  # can't pass it's GTK GUI startup. That only works if a display is set and
+  # Modern Gnucash can't even print version or help messages to the TTY if it
+  # can't pass its GTK GUI startup. That only works if a display is set and
   # an X-server is actually running there. So we have to wait for the whole
   # container to start up before we can test even the most basic gnucash
   # invocation.
@@ -38,7 +38,7 @@ load utils
 }
 
 # To get the GNC_* variables that the installed gnucash app is using, we need
-# to run 'gnucach --paths' in the environment context that the already started
+# to run 'gnucash --paths' in the environment context that the already started
 # gnucash process is operating in.
 
 @test "Checking Gnucash GNC_DATA_HOME points to /config..." {

--- a/tests/utils_container.bash
+++ b/tests/utils_container.bash
@@ -123,6 +123,6 @@ exec_in_container_app_env() {
   wait_for_container_daemon
 
   # This function is already called with run. We don't want to use nested
-  # 'run' to capture output overwriting $lines[@]. So we captue it by hand.
+  # 'run' to capture output overwriting $lines[@]. So we capture it by hand.
   exec_in_container sh -c ". ${CONTAINER_COM_DIR}/appenv.sh; $*"
 }


### PR DESCRIPTION
This PR fixes several typos and grammatical errors found in the `README.md` file and various test scripts.

**Changes:**
- **README.md**: Capitalized "Docker" for consistency.
- **tests/test_gnucash.bats**: Fixed "verion" to "version", corrected "it's" to "its" (possessive), and fixed "gnucach" to "gnucash".
- **tests/test_finance_quote.bats**: Changed "quota issue" to "quota issues" for plural agreement.
- **tests/utils_container.bash**: Fixed "captue" to "capture".

These changes are purely textual and do not affect the logic or functionality of the codebase.

---
*PR created automatically by Jules for task [4885466518465101077](https://jules.google.com/task/4885466518465101077) started by @ArturKlauser*