### PR TITLE
Update oauth2-proxy version to 7.15.2

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@
 #     --build-arg GNUCASH_VERSION=5.14 .
 ARG BASEIMAGE_VERSION=undefined
 ARG GNUCASH_VERSION=undefined
-ARG OAUTH2_PROXY_VERSION=v7.14.3
+ARG OAUTH2_PROXY_VERSION=v7.15.2
 # The following args can optionally be overridden on the command line.
 ARG WITH_DOCS=true
 ARG WITH_FINANCE_QUOTE=true


### PR DESCRIPTION
This change updates the `OAUTH2_PROXY_VERSION` argument in `docker/Dockerfile` from `v7.14.3` to `v7.15.2` as requested. All instances of the old version number have been replaced.

---
*PR created automatically by Jules for task [1983599444846729233](https://jules.google.com/task/1983599444846729233) started by @ArturKlauser*