### PR TITLE
Update baseimage version from 4.11.2 to 4.11.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  BASEIMAGE_VERSION: ubuntu-24.04-v4.11.2
+  BASEIMAGE_VERSION: ubuntu-24.04-v4.11.3
   GNUCASH_VERSION: 5.14
   PLATFORMS: linux/amd64,linux/arm64
   DOCKER_IMAGE_NAME: ${{ vars.DOCKERHUB_USERNAME }}/gnucash

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Docker image is based on
 
 ## Features
 
-* **Versions**: Runs GnuCash 5.14 on baseimage-gui:ubuntu-24.04-v4.11.2.
+* **Versions**: Runs GnuCash 5.14 on baseimage-gui:ubuntu-24.04-v4.11.3.
 * **Web Interface**: Access the GnuCash GUI through your web browser.
 * **Secure Access**: Web interface is forced to HTTPS and optionally secured by
   a login page.
@@ -235,7 +235,7 @@ docker run -d \
 To build the image locally:
 ```bash
 docker buildx build \
-  --build-arg BASEIMAGE_VERSION=ubuntu-24.04-v4.11.2 \
+  --build-arg BASEIMAGE_VERSION=ubuntu-24.04-v4.11.3 \
   --build-arg GNUCASH_VERSION=5.14 \
   -t gnucash docker
 ```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,7 +2,7 @@
 # These args MUST be set on the "docker build" command line.
 # Example:
 #   docker buildx build \
-#     --build-arg BASEIMAGE_VERSION=ubuntu-24.04-v4.11.2 \
+#     --build-arg BASEIMAGE_VERSION=ubuntu-24.04-v4.11.3 \
 #     --build-arg GNUCASH_VERSION=5.14 .
 ARG BASEIMAGE_VERSION=undefined
 ARG GNUCASH_VERSION=undefined


### PR DESCRIPTION
Updates baseimage version from 4.11.2 to 4.11.3 in docker/Dockerfile, .github/workflows/ci.yml and README.md

---
*PR created automatically by Jules for task [1600669239378297157](https://jules.google.com/task/1600669239378297157) started by @ArturKlauser*